### PR TITLE
First attempt to ring-divergence: reduce # retries

### DIFF
--- a/src/main/scala/com/walmartlabs/mupd8/MUCluster.scala
+++ b/src/main/scala/com/walmartlabs/mupd8/MUCluster.scala
@@ -57,12 +57,15 @@ class MUCluster[T <: MapUpdateClass[T]](self: Host,
 
   def send(dest: Host, obj: T) {
     def _send(retryCount: Int, destip: String, obj: T): Boolean = {
-      if (retryCount == 0) {
+      if (appRun.candidateRing != null && !appRun.candidateRing.ips.contains(destip)) {
+        warn ("Did not send this event, because its destination is unreachable and will be removed from the ring")
+        false
+      } else if (retryCount == 0) {
         false
       } else {
         if (!client.send(destip, obj)) {
           warn("Failed to send event (" + obj + ") to destination " + destip + " at retry : " + retryCount)
-          Thread.sleep(10000)
+          Thread.sleep(5000)
           _send(retryCount - 1, destip, obj)
         } else {
           true


### PR DESCRIPTION
What is the ring-divergence issue?
Ring divergence will happen after a 'hard' failure happened on
a MapUpdate node (e.g. power outage), the result is the remaining
live node will have different images of the hash ring.

How ring divergence is triggered?
After a node is reported as 'failed', the Message Server (MS) will
simultaneously notify other live nodes to get prepared and ack for
the ring change. The total time for this prep and ack phase is 90
seconds. (90s could be an empirical number). In case a live node can not
ack within 90s, it will be reported as an 'additional' failed node that
fails to prep and ack for the ring change and will be kicked out from
the live nodes. (In bad cases, two or more nodes are removed from ring
at one time.)

The above logic sounds reasonable, but there is a scenario that a live
node will be wrongly marked as failed node. Because of this, the ring
divergence is triggered.

How to resolve ring-divergence issue?
If a 'hard' failure happened on a node, some on-the-fly jobs on live nodes
(submitted before the failure was noticed by Mupd8) still need to ping/send
events to the failed node with certain number of retries (6 retries). The time
cost of retrying and then finding out the remote node is unreachable is very big,
especially for the 'hard' failure case where detecting a remote host is
unreachable via network needs much more turnaround time than a 'soft' failure (e.g. app
exits). So it is very easy for a live node to run out of 90s, just for pinging the
failed node, without doing any actual prep and ack work. The result is
that the live node is marked as "failed" node (but it is still live) and removed from
the ring consequently.

One way to make this above scenario looks better is to reduce the number
of 'unnecessary' retries. The 'unnecessary' retry is defined as: after
Mupd8 makes sure that a node is unreachable and should be removed from ring,
pinging/sending events to that failed node is 'unnecessary'.

A proposal in this change is: during the phase of the ring being changed, before an
event is sent over network, check if its destination is the failed node. If yes,
do not try or retry to send the event to failed node.

In addition, this change also reduces the pause time between two retries.
